### PR TITLE
Fix rollup output path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 node_modules/
 .env
 *.log
-dist/
 __pycache__/
 .vscode/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ cd vault_summary-engine
 npm install
 ```
 
-Build the plugin to generate the `dist/` folder:
+Build the plugin to generate `main.js`:
 
 ```bash
 npm run build
 ```
 
-Copy `manifest.json`, `styles.css` and the contents of `dist/` into your Obsidian vault's `.obsidian/plugins/vault-summary-engine/` folder and enable the plugin from Obsidian's settings.
+Copy `manifest.json`, `styles.css` and `main.js` into your Obsidian vault's `.obsidian/plugins/vault-summary-engine/` folder and enable the plugin from Obsidian's settings.
 Refer to `versions.json` for the minimum supported Obsidian version for each plugin release.
 
 ---
@@ -44,7 +44,7 @@ Refer to `versions.json` for the minimum supported Obsidian version for each plu
 src/           → TypeScript source files
 styles.css     → Plugin styles
 manifest.json  → Obsidian plugin manifest
-dist/          → Compiled output
+main.js        → Compiled output
 versions.json  → Maps plugin versions to minimum Obsidian version
 ```
 
@@ -53,6 +53,16 @@ versions.json  → Maps plugin versions to minimum Obsidian version
 ## 🤝 Contributing
 
 Contributions are welcome! Feel free to open issues or pull requests. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+---
+
+## 🚢 Publishing a Release
+
+Before creating a release, ensure the compiled file is up to date by running:
+
+```bash
+npm run build
+```
 
 ---
 

--- a/main.js
+++ b/main.js
@@ -1,0 +1,61 @@
+import { Plugin, PluginSettingTab, Setting } from 'obsidian';
+import SummaryEngine from './summaryEngine';
+import { SummaryPanel, VIEW_TYPE_SUMMARY } from './uiPanel';
+const DEFAULT_SETTINGS = {
+    includeFolders: ''
+};
+export default class VaultSummaryEnginePlugin extends Plugin {
+    async onload() {
+        await this.loadSettings();
+        this.engine = new SummaryEngine(this.app);
+        this.registerView(VIEW_TYPE_SUMMARY, leaf => new SummaryPanel(leaf, this.engine));
+        this.addRibbonIcon('document', 'Open Vault Summary', () => {
+            this.activateView();
+        });
+        this.addCommand({
+            id: 'refresh-vault-summary',
+            name: 'Refresh Vault Summary',
+            callback: async () => {
+                const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_SUMMARY);
+                for (const leaf of leaves) {
+                    await leaf.view.onOpen();
+                }
+            }
+        });
+        this.addSettingTab(new SummarySettingTab(this.app, this));
+    }
+    onunload() {
+        this.app.workspace.detachLeavesOfType(VIEW_TYPE_SUMMARY);
+    }
+    async activateView() {
+        await this.app.workspace.getRightLeaf(false).setViewState({ type: VIEW_TYPE_SUMMARY, active: true });
+    }
+    async loadSettings() {
+        this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+    }
+    async saveSettings() {
+        await this.saveData(this.settings);
+    }
+}
+class SummarySettingTab extends PluginSettingTab {
+    constructor(app, plugin) {
+        super(app, plugin);
+        this.plugin = plugin;
+    }
+    display() {
+        const { containerEl } = this;
+        containerEl.empty();
+        containerEl.createEl('h2', { text: 'Vault Summary Engine Settings' });
+        new Setting(containerEl)
+            .setName('Included folders')
+            .setDesc('Comma separated list of folders to index')
+            .addText(text => text
+            .setPlaceholder('folder1, folder2')
+            .setValue(this.plugin.settings.includeFolders)
+            .onChange(async (value) => {
+            this.plugin.settings.includeFolders = value;
+            await this.plugin.saveSettings();
+        }));
+    }
+}
+//# sourceMappingURL=main.js.map

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "description": "Generate summaries of your vault's notes.",
   "author": "PtiCalin",
   "authorUrl": "https://github.com/PtiCalin",
-  "main": "dist/main.js",
+  "main": "main.js",
   "css": "styles.css",
   "isDesktopOnly": false
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ import { terser } from 'rollup-plugin-terser';
 export default {
   input: 'src/main.ts',
   output: {
-    dir: 'dist',
+    file: 'main.js',
     sourcemap: 'inline',
     format: 'cjs'
   },


### PR DESCRIPTION
## Summary
- compile to `main.js` instead of `dist/`
- point manifest at the new output
- stop ignoring the `dist/` folder
- document build and release steps in README
- include the generated `main.js`

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d0502aa48322a22a637a113274f4