### PR TITLE
Remove unused MetadataCache import

### DIFF
--- a/src/summaryEngine.ts
+++ b/src/summaryEngine.ts
@@ -1,4 +1,4 @@
-import { App, TFile, MetadataCache } from 'obsidian';
+import { App, TFile } from 'obsidian';
 import { extractKeywords, readingTime, wordCount } from './utils';
 
 export interface NoteSummary {


### PR DESCRIPTION
## Summary
- trim `MetadataCache` from `summaryEngine` import list

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'obsidian')*
- `npm install` *(fails: 403 Forbidden during package fetch)*

------
https://chatgpt.com/codex/tasks/task_e_6845d21ceed8832280b181614c3d6661