### PR TITLE
Add automatic setup script

### DIFF
--- a/.config/setup.sh
+++ b/.config/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+cd "$(dirname "$0")/.."
+npm install

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ git clone https://github.com/PtiCalin/vault_summary-engine.git
 cd vault_summary-engine
 npm install
 ```
+In Codex environments, `.config/setup.sh` runs automatically to install dependencies.
 
 Build the plugin to generate `main.js`:
 


### PR DESCRIPTION
## Summary
- add `.config/setup.sh` to install dependencies
- note in README that Codex runs the setup script automatically