### PR TITLE
Add setup notes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ npm run build
 Copy `manifest.json`, `styles.css` and `main.js` into your Obsidian vault's `.obsidian/plugins/vault-summary-engine/` folder and enable the plugin from Obsidian's settings.
 Refer to `versions.json` for the minimum supported Obsidian version for each plugin release.
 
+## Setup Notes
+
+Dependencies are installed automatically by `.config/setup.sh`. If you are in an offline environment, request or configure outbound internet access so this script can run, or prepackage the `node_modules` directory.
+
 ---
 
 ## 🧱 Folder Structure


### PR DESCRIPTION
## Summary
- document that `.config/setup.sh` installs dependencies
- explain offline environment setup workaround
