### PR TITLE
Add single-line header comments

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,8 @@
-/*
- * === main.ts ===
- * Purpose: Obsidian plugin entry point and settings management.
- * Dependencies: obsidian, summaryEngine.ts, uiPanel.ts
- * Output: VaultSummaryEnginePlugin and SummarySettingTab
- * ---
- */
+// === main.ts ===
+// Purpose: Obsidian plugin entry point and settings management
+// Dependencies: obsidian, summaryEngine.ts, uiPanel.ts
+// Output: VaultSummaryEnginePlugin and SummarySettingTab
+// ---
 import { Plugin, PluginSettingTab, Setting, WorkspaceLeaf } from 'obsidian';
 import SummaryEngine from './summaryEngine';
 import { SummaryPanel, VIEW_TYPE_SUMMARY } from './uiPanel';

--- a/src/summaryEngine.ts
+++ b/src/summaryEngine.ts
@@ -1,10 +1,8 @@
-/*
- * === summaryEngine.ts ===
- * Purpose: Build note summaries by scanning the vault.
- * Dependencies: obsidian, utils.ts
- * Output: NoteSummary interface and SummaryEngine class
- * ---
- */
+// === summaryEngine.ts ===
+// Purpose: Build note summaries by scanning the vault
+// Dependencies: obsidian, utils.ts
+// Output: NoteSummary interface and SummaryEngine class
+// ---
 import { App, TFile } from 'obsidian';
 import { extractKeywords, readingTime, wordCount } from './utils';
 

--- a/src/uiPanel.ts
+++ b/src/uiPanel.ts
@@ -1,10 +1,8 @@
-/*
- * === uiPanel.ts ===
- * Purpose: Render the vault summary panel view.
- * Dependencies: obsidian, summaryEngine.ts
- * Output: SummaryPanel class and VIEW_TYPE_SUMMARY constant
- * ---
- */
+// === uiPanel.ts ===
+// Purpose: Render the vault summary panel view
+// Dependencies: obsidian, summaryEngine.ts
+// Output: SummaryPanel class and VIEW_TYPE_SUMMARY constant
+// ---
 import { ItemView, WorkspaceLeaf } from 'obsidian';
 import SummaryEngine, { NoteSummary } from './summaryEngine';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,8 @@
-/*
- * === utils.ts ===
- * Purpose: Helper functions for analyzing text.
- * Dependencies: none
- * Output: wordCount, readingTime, extractKeywords
- * ---
- */
+// === utils.ts ===
+// Purpose: Helper functions for analyzing text
+// Dependencies: none
+// Output: wordCount, readingTime, extractKeywords
+// ---
 /**
  * 🧠 Counts the number of words in a text string.
  *


### PR DESCRIPTION
## Summary
- convert multi-line headers to single-line comment style in all `src` files

## Testing
- `npm run build` *(fails: rollup not found)*
