### PR TITLE
Handle read failures when indexing

### DIFF
--- a/src/summaryEngine.ts
+++ b/src/summaryEngine.ts
@@ -42,7 +42,13 @@ export default class SummaryEngine {
         const files = this.app.vault.getMarkdownFiles();
         const summaries: NoteSummary[] = [];
         for (const file of files) {
-            const content = await this.app.vault.cachedRead(file);
+            let content: string;
+            try {
+                content = await this.app.vault.cachedRead(file);
+            } catch (err) {
+                console.warn(`⚠️ Could not read ${file.path}`);
+                continue;
+            }
             const fm = this.app.metadataCache.getFileCache(file)?.frontmatter ?? {};
             const tags = Array.isArray(fm.tags)
                 ? fm.tags


### PR DESCRIPTION
## Summary
- make the summary engine resilient when reading vault files

## Testing
- `npm run build` *(fails: rollup not found)*